### PR TITLE
Bump symfony/dependency-injection to 6.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     ],
     "require": {
         "php": ">=8.1",
-        "symfony/dependency-injection": "6.1.*",
+        "symfony/dependency-injection": "^6.2",
         "symfony/console": "^6.2",
         "nette/robot-loader": "^3.4",
         "symplify/symplify-kernel": "^11.1",


### PR DESCRIPTION
![2023-05-09 10 44 24 github com 352308ffb5cf](https://user-images.githubusercontent.com/8054960/237044121-b3d51c01-392b-4cdc-9a4e-cc8f838fc944.png)

From the `symfony/dependency-injection` I don't see any breaking changes, and the pipeline passes. Any reason why the change was reverted and the dependency pinned to `6.1.*`?