### PR TITLE
Fix --skip-type "Type\To\Skip" command on vendor/bin/rule-doc-generator generate command

### DIFF
--- a/src/DependencyInjection/ContainerFactory.php
+++ b/src/DependencyInjection/ContainerFactory.php
@@ -54,10 +54,9 @@ final class ContainerFactory
             $generateCommand = $container->make(GenerateCommand::class);
             $application->add($generateCommand);
 
-            $this->propertyCallable($application, 'commands', function (array $defaultCommands) {
+            $this->propertyCallable($application, 'commands', static function (array $defaultCommands) {
                 unset($defaultCommands['completion']);
                 unset($defaultCommands['help']);
-
                 return $defaultCommands;
             });
 

--- a/src/DirectoryToMarkdownPrinter.php
+++ b/src/DirectoryToMarkdownPrinter.php
@@ -80,7 +80,7 @@ final class DirectoryToMarkdownPrinter
             $ruleClassWithFilePaths,
             static function (RuleClassWithFilePath $ruleClassWithFilePath) use ($skipTypes): bool {
                 foreach ($skipTypes as $skipType) {
-                    if ($ruleClassWithFilePath instanceof $skipType) {
+                    if (is_a($ruleClassWithFilePath->getClass(), $skipType, true)) {
                         return false;
                     }
                 }


### PR DESCRIPTION
The current check is comparing `RuleClassWithFilePath` object with string, which always `false`, this patch ensure pass the class name to compare with `is_a()` instead to allow run `--skip-type` usage in generate command.